### PR TITLE
Port to 1.21.10

### DIFF
--- a/common/src/main/java/dev/lieonlion/mcv/access/ChestRenderStateAccess.java
+++ b/common/src/main/java/dev/lieonlion/mcv/access/ChestRenderStateAccess.java
@@ -1,0 +1,11 @@
+package dev.lieonlion.mcv.access;
+
+public interface ChestRenderStateAccess {
+    boolean lolmcv$isMoreChest();
+    boolean lolmcv$isTrapped();
+    String lolmcv$woodVariant();
+
+    void lolmcv$setMoreChest(boolean b);
+    void lolmcv$setTrapped(boolean b);
+    void lolmcv$setWoodVariant(String s);
+}

--- a/common/src/main/java/dev/lieonlion/mcv/block/MoreChestBlock.java
+++ b/common/src/main/java/dev/lieonlion/mcv/block/MoreChestBlock.java
@@ -5,6 +5,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.CompoundContainer;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
@@ -60,7 +61,7 @@ public class MoreChestBlock extends ChestBlock {
     public final String woodType;
 
     public MoreChestBlock(Supplier<BlockEntityType<? extends ChestBlockEntity>> blockEntityType, Properties properties, String woodType) {
-        super(blockEntityType, properties);
+        super(blockEntityType, SoundEvents.CHEST_OPEN, SoundEvents.CHEST_CLOSE, properties);
         this.woodType = woodType;
     }
 

--- a/fabric/src/main/java/dev/lieonlion/mcv/mixin/client/FabricChestRenderStateMixin.java
+++ b/fabric/src/main/java/dev/lieonlion/mcv/mixin/client/FabricChestRenderStateMixin.java
@@ -1,0 +1,53 @@
+package dev.lieonlion.mcv.mixin.client;
+
+import dev.lieonlion.mcv.access.ChestRenderStateAccess;
+import net.minecraft.client.renderer.blockentity.state.ChestRenderState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(ChestRenderState.class)
+public class FabricChestRenderStateMixin implements ChestRenderStateAccess {
+    @Unique
+    public boolean lolmcv$moreChest;
+    @Unique
+    public boolean lolmcv$trapped;
+    @Unique
+    public String lolmcv$woodVariant;
+
+
+    public FabricChestRenderStateMixin() {
+        lolmcv$moreChest = false;
+        lolmcv$trapped = false;
+        lolmcv$woodVariant = "";
+    }
+
+    @Override
+    public boolean lolmcv$isMoreChest() {
+        return lolmcv$moreChest;
+    }
+
+    @Override
+    public boolean lolmcv$isTrapped() {
+        return lolmcv$trapped;
+    }
+
+    @Override
+    public String lolmcv$woodVariant() {
+        return lolmcv$woodVariant;
+    }
+
+    @Override
+    public void lolmcv$setMoreChest(boolean b) {
+        lolmcv$moreChest = b;
+    }
+
+    @Override
+    public void lolmcv$setTrapped(boolean b) {
+        lolmcv$trapped = b;
+    }
+
+    @Override
+    public void lolmcv$setWoodVariant(String s) {
+        lolmcv$woodVariant = s;
+    }
+}

--- a/fabric/src/main/java/dev/lieonlion/mcv/mixin/client/FabricChestRendererMixin.java
+++ b/fabric/src/main/java/dev/lieonlion/mcv/mixin/client/FabricChestRendererMixin.java
@@ -2,17 +2,29 @@ package dev.lieonlion.mcv.mixin.client;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import dev.lieonlion.mcv.MoreChestVariants;
+import dev.lieonlion.mcv.access.ChestRenderStateAccess;
 import dev.lieonlion.mcv.block.MoreChestBlock;
 import dev.lieonlion.mcv.block.MoreTrappedChestBlock;
+import dev.lieonlion.mcv.block.entity.MoreChestBlockEntity;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.blockentity.ChestRenderer;
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.blockentity.state.ChestRenderState;
+import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.resources.model.Material;
+import net.minecraft.world.level.block.TrappedChestBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.block.entity.LidBlockEntity;
 import net.minecraft.world.level.block.state.properties.ChestType;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Calendar;
 
@@ -27,15 +39,25 @@ public class FabricChestRendererMixin {
         return (calendar.get(2) + 1 == 5 && calendar.get(5) >= 3 && calendar.get(5) <= 5);
     }
 
-    @WrapOperation(method = "render(Lnet/minecraft/world/level/block/entity/BlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IILnet/minecraft/world/phys/Vec3;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Sheets;chooseMaterial(Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/minecraft/world/level/block/state/properties/ChestType;Z)Lnet/minecraft/client/resources/model/Material;"))
-    private Material lolmcv$getChestMaterial(BlockEntity blockEntity, ChestType type, boolean xmas, Operation<Material> original) {
-        if (!xmas && blockEntity.getBlockState().getBlock() instanceof MoreChestBlock moreChestBlock) {
+    @WrapOperation(method = "submit(Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Sheets;chooseMaterial(Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState$ChestMaterialType;Lnet/minecraft/world/level/block/state/properties/ChestType;)Lnet/minecraft/client/resources/model/Material;"))
+    private Material lolmcv$getChestMaterial(ChestRenderState.ChestMaterialType chestMaterialType, ChestType type, Operation<Material> original, @Local ChestRenderState chestRenderState) {
+        if (!ChestRenderer.xmasTextures() && chestRenderState instanceof ChestRenderStateAccess moreChestBlock && moreChestBlock.lolmcv$isMoreChest()) {
             if (lolmcv$starwars && MoreChestVariants.CONFIG.displayStarWarsTextures()) {
                 return lolmcv$chooseMaterial(type, "starwars");
-            } else if (moreChestBlock instanceof MoreTrappedChestBlock) {
-                return lolmcv$chooseMaterial(type, "trapped/" + moreChestBlock.woodType);
-            } return lolmcv$chooseMaterial(type, moreChestBlock.woodType);
-        } return original.call(blockEntity, type, xmas);
+            } else if (moreChestBlock.lolmcv$isTrapped()) {
+                return lolmcv$chooseMaterial(type, "trapped/" + moreChestBlock.lolmcv$woodVariant());
+            } return lolmcv$chooseMaterial(type, moreChestBlock.lolmcv$woodVariant());
+        } return original.call(chestMaterialType, type);
+    }
+
+    @Inject(method = "extractRenderState(Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState;FLnet/minecraft/world/phys/Vec3;Lnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V", at = @At(value = "RETURN"))
+    private <T extends BlockEntity & LidBlockEntity> void mixin(T blockEntity, ChestRenderState chestRenderState, float f, Vec3 vec3, ModelFeatureRenderer.CrumblingOverlay crumblingOverlay, CallbackInfo ci) {
+        var access = ((ChestRenderStateAccess) chestRenderState);
+        if (blockEntity.getBlockState().getBlock() instanceof MoreChestBlock moreChestBlock) {
+            access.lolmcv$setMoreChest(true);
+            access.lolmcv$setTrapped(blockEntity.getBlockState().getBlock() instanceof MoreTrappedChestBlock);
+            access.lolmcv$setWoodVariant(moreChestBlock.woodType);
+        }
     }
 
     @Unique

--- a/fabric/src/main/resources/lolmcv.fabric.mixins.json
+++ b/fabric/src/main/resources/lolmcv.fabric.mixins.json
@@ -8,6 +8,7 @@
     "FabricCreativeModeTabsMixin"
   ],
   "client": [
+    "client.FabricChestRenderStateMixin",
     "client.FabricChestRendererMixin"
   ],
   "server": [],

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,40 +19,40 @@ mod_link_issues=https://github.com/lieonlion/More-Chest-Variants/issues
 
 # Common
 
-minecraft_version=1.21.8
-minecraft_fabric_version_range=>=1.21.6 <=1.21.8
-minecraft_neo_version_range=[1.21.6, 1.21.8)
+minecraft_version=1.21.10
+minecraft_fabric_version_range=>=1.21.9 <=1.21.10
+minecraft_neo_version_range=[1.21.9, 1.21.10)
 java_version=21
 
 # Fabric
 
-fabric_version=0.130.0+1.21.8
-fabric_loader_version=0.17.2
-loom_version=1.10-SNAPSHOT
+fabric_version=0.136.0+1.21.10
+fabric_loader_version=0.17.3
+loom_version=1.11-SNAPSHOT
 
 # NeoForge
 
-neoforge_version=21.8.31
+neoforge_version=21.10.29-beta
 neoforge_loader_version_range=[4,)
 neoforge_moddev_version=2.0.107
-neo_form_version=1.21.8-20250717.133445
+neo_form_version=1.21.10-20251010.172816
 # ParchmentMC
-parchment_minecraft=1.21.8
-parchment_version=2025.07.20
+parchment_minecraft=1.21.10
+parchment_version=2025.10.12
 
 # Dependencies
 
 # Quad Properties
 quad_version=1.2.14
-quad_minecraft_version=1.21.8
+quad_minecraft_version=1.21.9
 quad_version_range=~1.2.12
 
 # Sodium Properties
-sodium_version=0.6.13
-sodium_minecraft_version=1.21.6
+sodium_version=0.7.2
+sodium_minecraft_version=1.21.10
 
 # ModMenu Properties
-modmenu_version=15.0.0-beta.3
+modmenu_version=16.0.0-rc.1
 
 # YACL Properties
-yacl_version=3.7.1+1.21.6
+yacl_version=3.8.0+1.21.9

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/src/main/java/dev/lieonlion/mcv/NeoForgeMoreChestVariants.java
+++ b/neoforge/src/main/java/dev/lieonlion/mcv/NeoForgeMoreChestVariants.java
@@ -9,7 +9,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
-import net.neoforged.neoforge.items.wrapper.InvWrapper;
+import net.neoforged.neoforge.transfer.item.VanillaContainerWrapper;
 
 import java.util.List;
 import java.util.Objects;
@@ -34,8 +34,8 @@ public class NeoForgeMoreChestVariants {
         );
 
         for (var type: variantChestEntities) {
-            event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, type,
-                ((be, direction) -> new InvWrapper(
+            event.registerBlockEntity(Capabilities.Item.BLOCK, type,
+                ((be, direction) -> VanillaContainerWrapper.of(
                     Objects.requireNonNull(ChestBlock.getContainer(be.getMoreChestBlock(), be.getBlockState(), Objects.requireNonNull(be.getLevel()), be.getBlockPos(), true)))
                 )
             );

--- a/neoforge/src/main/java/dev/lieonlion/mcv/mixin/client/NeoForgeChestRenderStateMixin.java
+++ b/neoforge/src/main/java/dev/lieonlion/mcv/mixin/client/NeoForgeChestRenderStateMixin.java
@@ -1,0 +1,53 @@
+package dev.lieonlion.mcv.mixin.client;
+
+import dev.lieonlion.mcv.access.ChestRenderStateAccess;
+import net.minecraft.client.renderer.blockentity.state.ChestRenderState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(ChestRenderState.class)
+public class NeoForgeChestRenderStateMixin implements ChestRenderStateAccess {
+    @Unique
+    public boolean lolmcv$moreChest;
+    @Unique
+    public boolean lolmcv$trapped;
+    @Unique
+    public String lolmcv$woodVariant;
+
+
+    public NeoForgeChestRenderStateMixin() {
+        lolmcv$moreChest = false;
+        lolmcv$trapped = false;
+        lolmcv$woodVariant = "";
+    }
+
+    @Override
+    public boolean lolmcv$isMoreChest() {
+        return lolmcv$moreChest;
+    }
+
+    @Override
+    public boolean lolmcv$isTrapped() {
+        return lolmcv$trapped;
+    }
+
+    @Override
+    public String lolmcv$woodVariant() {
+        return lolmcv$woodVariant;
+    }
+
+    @Override
+    public void lolmcv$setMoreChest(boolean b) {
+        lolmcv$moreChest = b;
+    }
+
+    @Override
+    public void lolmcv$setTrapped(boolean b) {
+        lolmcv$trapped = b;
+    }
+
+    @Override
+    public void lolmcv$setWoodVariant(String s) {
+        lolmcv$woodVariant = s;
+    }
+}

--- a/neoforge/src/main/java/dev/lieonlion/mcv/mixin/client/NeoForgeChestRendererMixin.java
+++ b/neoforge/src/main/java/dev/lieonlion/mcv/mixin/client/NeoForgeChestRendererMixin.java
@@ -2,17 +2,25 @@ package dev.lieonlion.mcv.mixin.client;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import dev.lieonlion.mcv.MoreChestVariants;
+import dev.lieonlion.mcv.access.ChestRenderStateAccess;
 import dev.lieonlion.mcv.block.MoreChestBlock;
 import dev.lieonlion.mcv.block.MoreTrappedChestBlock;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.blockentity.ChestRenderer;
+import net.minecraft.client.renderer.blockentity.state.ChestRenderState;
+import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.LidBlockEntity;
 import net.minecraft.world.level.block.state.properties.ChestType;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Calendar;
 
@@ -27,15 +35,25 @@ public class NeoForgeChestRendererMixin {
         return (calendar.get(2) + 1 == 5 && calendar.get(5) >= 3 && calendar.get(5) <= 5);
     }
 
-    @WrapOperation(method = "getMaterial", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Sheets;chooseMaterial(Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/minecraft/world/level/block/state/properties/ChestType;Z)Lnet/minecraft/client/resources/model/Material;"))
-    private Material lolmcv$getChestMaterial(BlockEntity blockEntity, ChestType type, boolean xmas, Operation<Material> original) {
-        if (!xmas && blockEntity.getBlockState().getBlock() instanceof MoreChestBlock moreChestBlock) {
+    @WrapOperation(method = "submit(Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/Sheets;chooseMaterial(Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState$ChestMaterialType;Lnet/minecraft/world/level/block/state/properties/ChestType;)Lnet/minecraft/client/resources/model/Material;"))
+    private Material lolmcv$getChestMaterial(ChestRenderState.ChestMaterialType chestMaterialType, ChestType type, Operation<Material> original, @Local ChestRenderState chestRenderState) {
+        if (!ChestRenderer.xmasTextures() && chestRenderState instanceof ChestRenderStateAccess moreChestBlock && moreChestBlock.lolmcv$isMoreChest()) {
             if (lolmcv$starwars && MoreChestVariants.CONFIG.displayStarWarsTextures()) {
                 return lolmcv$chooseMaterial(type, "starwars");
-            } else if (moreChestBlock instanceof MoreTrappedChestBlock) {
-                return lolmcv$chooseMaterial(type, "trapped/" + moreChestBlock.woodType);
-            } return lolmcv$chooseMaterial(type, moreChestBlock.woodType);
-        } return original.call(blockEntity, type, xmas);
+            } else if (moreChestBlock.lolmcv$isTrapped()) {
+                return lolmcv$chooseMaterial(type, "trapped/" + moreChestBlock.lolmcv$woodVariant());
+            } return lolmcv$chooseMaterial(type, moreChestBlock.lolmcv$woodVariant());
+        } return original.call(chestMaterialType, type);
+    }
+
+    @Inject(method = "extractRenderState(Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/minecraft/client/renderer/blockentity/state/ChestRenderState;FLnet/minecraft/world/phys/Vec3;Lnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V", at = @At(value = "RETURN"))
+    private <T extends BlockEntity & LidBlockEntity> void mixin(T blockEntity, ChestRenderState chestRenderState, float f, Vec3 vec3, ModelFeatureRenderer.CrumblingOverlay crumblingOverlay, CallbackInfo ci) {
+        var access = ((ChestRenderStateAccess) chestRenderState);
+        if (blockEntity.getBlockState().getBlock() instanceof MoreChestBlock moreChestBlock) {
+            access.lolmcv$setMoreChest(true);
+            access.lolmcv$setTrapped(blockEntity.getBlockState().getBlock() instanceof MoreTrappedChestBlock);
+            access.lolmcv$setWoodVariant(moreChestBlock.woodType);
+        }
     }
 
     @Unique

--- a/neoforge/src/main/resources/lolmcv.neoforge.mixins.json
+++ b/neoforge/src/main/resources/lolmcv.neoforge.mixins.json
@@ -7,6 +7,7 @@
     "NeoForgeCreativeModeTabsMixin"
   ],
   "client": [
+    "client.NeoForgeChestRenderStateMixin",
     "client.NeoForgeChestRendererMixin"
   ],
   "server": [],

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ pluginManagement {
                 }
             }
             filter {
-                includeGroup('net.fabricmc')
+                includeGroupAndSubgroups('net.fabricmc')
                 includeGroup('fabric-loom')
             }
         }


### PR DESCRIPTION
- Adds a new mixin on both the Fabric and NeoForge sides - `ChestRenderStateMixin`, which provides the `ChestBlockEntityRenderer` mixin the context that its rendering a block from More Chest Variants. This is backed by the new `ChestRenderStateAccess` class.
- Migrates to NeoForge's 1.21.10 transfer API.
- Version bumps and minor migrations to build against 1.21.10.

Should work on 1.21.9 as well, untested.